### PR TITLE
Change dependencies from github.com/go-fsnotify/fsnotify to github.com/fsnotify/fsnotify

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -2,7 +2,7 @@ package tail
 
 import (
 	"bufio"
-	"github.com/go-fsnotify/fsnotify"
+	"github.com/fsnotify/fsnotify"
 	"log"
 	"os"
 	"path"


### PR DESCRIPTION
The site seems to be moved and obsolete.

Please see the following document for details. 🙇
https://github.com/go-fsnotify/fsnotify/blob/master/README.md

Thanks.